### PR TITLE
Bug fix for files on compound objects.

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -306,18 +306,18 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.16.0"
+version = "3.16.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.16.0-py3-none-any.whl", hash = "sha256:f6ed4c963184f4c84dd5557ce8fece759a3724b37b80c6c4f20a2f63a4dc6609"},
-    {file = "filelock-3.16.0.tar.gz", hash = "sha256:81de9eb8453c769b63369f87f11131a7ab04e367f8d97ad39dc230daa07e3bec"},
+    {file = "filelock-3.16.1-py3-none-any.whl", hash = "sha256:2082e5703d51fbf98ea75855d9d5527e33d8ff23099bec374a134febee6946b0"},
+    {file = "filelock-3.16.1.tar.gz", hash = "sha256:c249fbfcd5db47e5e2d6d62198e565475ee65e4831e2561c8e313fa7eb961435"},
 ]
 
 [package.extras]
-docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.1.1)", "pytest (>=8.3.2)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.3)"]
+docs = ["furo (>=2024.8.6)", "sphinx (>=8.0.2)", "sphinx-autodoc-typehints (>=2.4.1)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.6.1)", "diff-cover (>=9.2)", "pytest (>=8.3.3)", "pytest-asyncio (>=0.24)", "pytest-cov (>=5)", "pytest-mock (>=3.14)", "pytest-timeout (>=2.3.1)", "virtualenv (>=20.26.4)"]
 typing = ["typing-extensions (>=4.12.2)"]
 
 [[package]]
@@ -588,13 +588,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.3"
+version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "platformdirs-4.3.3-py3-none-any.whl", hash = "sha256:50a5450e2e84f44539718293cbb1da0a0885c9d14adf21b77bae4e66fc99d9b5"},
-    {file = "platformdirs-4.3.3.tar.gz", hash = "sha256:d4e0b7d8ec176b341fb03cb11ca12d0276faa8c485f9cd218f613840463fc2c0"},
+    {file = "platformdirs-4.3.6-py3-none-any.whl", hash = "sha256:73e575e1408ab8103900836b97580d5307456908a03e92031bab39e4554cc3fb"},
+    {file = "platformdirs-4.3.6.tar.gz", hash = "sha256:357fb2acbc885b0419afd3ce3ed34564c13c9b95c89360cd9563f73aa5e2b907"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "utk-exodus"
-version = "0.2.2"
+version = "0.2.3"
 description = "A tool for building import sheets from UTK legacy systems"
 authors = ["Mark Baggett <mbagget1@utk.edu>"]
 readme = "README.md"

--- a/utk_exodus/finder/finder.py
+++ b/utk_exodus/finder/finder.py
@@ -259,6 +259,8 @@ class RDFTypeGenerator:
             return self.__get_rdf_types_for_file_on_a_pdf_work(dsid, preserve_and_obj)
         elif self.parent_type == "Page":
             return self.__get_rdf_types_for_file_on_a_pdf_work(dsid, preserve_and_obj)
+        elif self.parent_type == "CompoundObject":
+            return self.__get_rdf_types_for_file_on_a_compound_object(dsid)
         else:
             raise Exception(f"Parent type unknown: {self.parent_type}")
 
@@ -358,6 +360,17 @@ class RDFTypeGenerator:
             return "http://pcdm.org/file-format-types#Document | http://pcdm.org/use#ServiceFile"
         elif dsid == "TEI":
             return "http://pcdm.org/file-format-types#Markup"
+        else:
+            return "http://pcdm.org/use#OriginalFile"
+
+    @staticmethod
+    def __get_rdf_types_for_file_on_a_compound_object(dsid):
+        if dsid == "MODS":
+            return "http://pcdm.org/file-format-types#Markup"
+        elif dsid == "AIP":
+            return "http://pcdm.org/use#PreservationFile"
+        elif dsid == "DIP":
+            return "http://pcdm.org/use#IntermediateFile"
         else:
             return "http://pcdm.org/use#OriginalFile"
 


### PR DESCRIPTION
This attempts to fix:

```
Traceback (most recent call last):
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/bin/exodus", line 6, in <module>
    sys.exit(cli())
             ^^^^^
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Library/Caches/pypoetry/virtualenvs/utk-exodus-xBCLoTSd-py3.11/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/exodus.py", line 146, in works_and_files
    interface.download_mods(collection, model)
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/controller/controller.py", line 152, in download_mods
    self.__grab_file_info()
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/controller/controller.py", line 78, in __grab_file_info
    x = FileOrganizer("tmp/works.csv", ["filesets", "attachments"], self.remote)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/finder/finder.py", line 17, in __init__
    self.new_csv_with_files = self.__add_files(what_to_add)
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/finder/finder.py", line 200, in __add_files
    new_csv_content.append(self.__add_an_attachment(dsid, row))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/finder/finder.py", line 74, in __add_an_attachment
    'rdf_type': RDFTypeGenerator(row['model']).find_file_types(filename, preserve_and_obj),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/westonagreda/Documents/utkdigitalinitiatives/utk-exodus/utk_exodus/finder/finder.py", line 263, in find_file_types
    raise Exception(f"Parent type unknown: {self.parent_type}")
Exception: Parent type unknown: CompoundObject
```

It's hard for me to test this, and there aren't built in unit tests for `finder`, `FileOrganizer`, etc.  I'd try fetching and checking this out before merging any thing here.  Do something like:

```
gh pr checkout 16
```

Then running the command that generated.  If everything works, great, but there might be another thing that gets thrown that might need to be fixed. Happy to review this together over a Zoom call or Slack huddle.