### PR TITLE
Adds option to exodus for fixing metadata sheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ delete
 test.py
 **/__pycache__/
 dist
+imports/
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "utk-exodus"
-version = "0.2.6"
+version = "0.2.9"
 description = "A tool for building import sheets from UTK legacy systems"
 authors = ["Mark Baggett <mbagget1@utk.edu>"]
 readme = "README.md"

--- a/utk_exodus/exodus.py
+++ b/utk_exodus/exodus.py
@@ -12,6 +12,7 @@ from utk_exodus.risearch import ResourceIndexSearch
 from utk_exodus.banish import BanishFiles
 from utk_exodus.fedora import FedoraObject
 from utk_exodus.review import ExistingImport
+from utk_exodus.fixes import FixMetadata
 import click
 import requests
 import os
@@ -396,3 +397,44 @@ def add_datastreams(
                 pid=pid,
             )
             fedora.add_datastream(dsid, os.path.join(path, file))
+
+@cli.command(
+    "fix_metadata_sheet",
+    help="Sorts and makes metadata fixes to filesets and attachments CSVs",
+)
+@click.option(
+    "--csv",
+    "-c",
+    required=True,
+    help="The CSV you want to read in or dir with only filesets and attachments CSVs",
+)
+@click.option(
+    "--titles",
+    "-t",
+    required=False,
+    default="MODS,Preserve,Release,Bioform,RELS-INT,HOCR,METS,ALTO",
+    help="Optionally specify which titles to restrict visibility for, default is MODS,Preserve,Release,Bioform,RELS-INT,HOCR,METS,ALTO",
+)
+@click.option(
+    "--remove_columns",
+    "-r",
+    required=False,
+    default="N",
+    help="Optionally specify if unnecessary columns should be removed (Y/N). Will remove everything except source_identifier', 'title', 'model', and 'visibility' columns",
+)
+def export_errors(
+    csv: str,
+    titles: str,
+    remove_columns: str
+) -> None:
+    rc = (remove_columns.lower() == "y" or remove_columns.lower() == "yes")
+    print(f"Running metadata fixes on {csv} and restricting {titles} " + ("and removing all columns except 'source_identifier', 'title', 'model', 'visibility'" if rc else "and keeping all columns"))
+    path = csv
+    updater = FixMetadata(titles, rc)
+    if os.path.isdir(path):
+        for filename in tqdm(os.listdir(path)):
+            if filename.endswith('.csv'):
+                csv_filename = os.path.join(path, filename)
+                updater.update_metadata(csv_filename)
+    else:
+        updater.update_metadata(path)

--- a/utk_exodus/exodus.py
+++ b/utk_exodus/exodus.py
@@ -422,7 +422,7 @@ def add_datastreams(
     default="N",
     help="Optionally specify if unnecessary columns should be removed (Y/N). Will remove everything except source_identifier', 'title', 'model', and 'visibility' columns",
 )
-def export_errors(
+def fix_metadata(
     csv: str,
     titles: str,
     remove_columns: str

--- a/utk_exodus/fixes/__init__.py
+++ b/utk_exodus/fixes/__init__.py
@@ -1,0 +1,3 @@
+from .fixes import FixMetadata
+
+__all__ = ["FixMetadata"]

--- a/utk_exodus/fixes/fixes.py
+++ b/utk_exodus/fixes/fixes.py
@@ -1,5 +1,3 @@
-import os
-import requests
 import csv
 import sys
 

--- a/utk_exodus/fixes/fixes.py
+++ b/utk_exodus/fixes/fixes.py
@@ -1,0 +1,45 @@
+import os
+import requests
+import csv
+import sys
+
+class FixMetadata:
+    def __init__(self, titles, remove_columns=False):
+        self.titles = titles
+        self.remove_columns = remove_columns
+
+    def update_metadata(self, csv_filename):
+        keywords = self.titles
+        remove_columns = self.remove_columns
+        keywords_list = [keyword.lower() for keyword in keywords.split(',')]
+        with open(csv_filename, mode='r', newline='') as infile:
+            reader = csv.DictReader(infile)
+            rows = list(reader)
+
+        attachment_rows = [row for row in rows if row['model'].lower() == 'attachment']
+        fileset_rows = [row for row in rows if row['model'].lower() == 'fileset']
+
+        if len(attachment_rows) + len(fileset_rows) != len(rows):
+            print("unexpected model in sheet")
+            sys.exit(1)
+
+        attachment_rows.sort(key=lambda row: ('obj' in row['title'].lower() or 'preserve' in row['title'].lower(), row['title'].lower()))
+        fileset_rows.sort(key=lambda row: ('obj' in row['title'].lower() or 'preserve' in row['title'].lower(), row['title'].lower()))
+        rows = attachment_rows + fileset_rows
+
+        with open(csv_filename, mode='w', newline='') as outfile:
+            fieldnames = reader.fieldnames
+            if remove_columns:
+                # Here are the columns that will not get removed when using the remove columns option
+                fieldnames = ['source_identifier', 'title', 'model', 'visibility']
+            writer = csv.DictWriter(outfile, fieldnames=fieldnames)
+            writer.writeheader()
+            for row in rows:
+                if any(keyword in row['title'].lower() for keyword in keywords_list):
+                    row['visibility'] = 'restricted'
+                if remove_columns:
+                    row = {key: row[key] for key in fieldnames}
+                writer.writerow(row)
+
+if __name__ == "__main__":
+    print("use this space to test metadata fixes if needed")


### PR DESCRIPTION
Adds fix_metadata_sheet option to exodus. This is for fixing up filesets and attachment sheets, it will sort them with attachments first, then filesets, as well as putting OBJ and Preserve at the bottom of the sheet. It will restrict rows, by default it will set all rows with MODS, Preserve, Release, Bioform, RELS-INT, HOCR, METS, and ALTO in their title. Optionally you can also remove all columns except for 'source_identifier', 'title', 'model', and 'visibility' so that reruns are faster.