### PR TITLE
adding rdf type fixes to metadata fixes tool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "utk-exodus"
-version = "0.2.9"
+version = "0.2.10"
 description = "A tool for building import sheets from UTK legacy systems"
 authors = ["Mark Baggett <mbagget1@utk.edu>"]
 readme = "README.md"

--- a/utk_exodus/finder/finder.py
+++ b/utk_exodus/finder/finder.py
@@ -337,6 +337,10 @@ class RDFTypeGenerator:
             return "http://pcdm.org/file-format-types#StructuredText"
         elif dsid == "MODS":
             return "http://pcdm.org/file-format-types#Markup"
+        elif dsid == "OCR":
+            return "http://pcdm.org/use#ExtractedText"
+        elif dsid == "HOCR":
+            return "http://pcdm.org/file-format-types#HTML"
         else:
             return "http://pcdm.org/use#OriginalFile"
 
@@ -351,7 +355,7 @@ class RDFTypeGenerator:
         elif dsid == "TRANSCRIPT":
             return "http://pcdm.org/use#Transcript"
         elif dsid == "OCR":
-            return "http://pcdm.org/use#Transcript"
+            return "http://pcdm.org/use#ExtractedText"
         elif dsid == "PDF":
             return "http://pcdm.org/file-format-types#Document | http://pcdm.org/use#ServiceFile"
         elif dsid == "ORIGINAL":

--- a/utk_exodus/fixes/fixes.py
+++ b/utk_exodus/fixes/fixes.py
@@ -25,6 +25,12 @@ class FixMetadata:
         fileset_rows.sort(key=lambda row: ('obj' in row['title'].lower() or 'preserve' in row['title'].lower(), row['title'].lower()))
         rows = attachment_rows + fileset_rows
 
+        for row in rows:
+            if row['title'].lower() == 'ocr':
+                row['rdf_type'] = 'http://pcdm.org/use#ExtractedText'
+            elif row['title'].lower() == 'hocr':
+                row['rdf_type'] = 'http://pcdm.org/file-format-types#HTML'
+
         with open(csv_filename, mode='w', newline='') as outfile:
             fieldnames = reader.fieldnames
             if remove_columns:


### PR DESCRIPTION
fixes rdf type for ocr and hocr on books and pdfs, and adds this fix to fix_metadata_sheet option 