### PR TITLE
Metadata fixes update

### DIFF
--- a/utk_exodus/fixes/fixes.py
+++ b/utk_exodus/fixes/fixes.py
@@ -1,5 +1,4 @@
 import csv
-import sys
 
 class FixMetadata:
     def __init__(self, titles, remove_columns=False):


### PR DESCRIPTION
Adds some extra error checking and basically allows you to run fixes on the large csv containing everything, as opposed to having to run it on a directory of all the fileset and attachment sheets. This way splitting the sheets can be done separately. 